### PR TITLE
Quirk that was stopping DRF settings being applied

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -3,6 +3,10 @@
 Settings in Knox are handled in a similar way to the rest framework settings.
 All settings are namespaced in the `'REST_KNOX'` setting.
 
+The Knox settings must come below the 'REST_FRAMEWORK' settings in 
+'settings.py', if you're going to reference their 'api_settings'. If the 
+rest framework settings come below, they will not be applied.
+
 Example `settings.py`
 
 ```python


### PR DESCRIPTION
I noticed the default authentication classes weren't applying for DRF, but this was fixed by placing the REST_KNOX settings below the REST_FRAMEWORK settings, or by commenting out the line containing 'api_settings.DATETIME_FORMAT'. Thought other people might find themselves in this situation!